### PR TITLE
PoC using keymap-drawer functions

### DIFF
--- a/src/zkeymap/generators.py
+++ b/src/zkeymap/generators.py
@@ -412,8 +412,6 @@ class _Namespace:
 def build_layout_svg_drawer(
     *,
     svg_file: str,
-    keymap_file: str,
-    layout_json_file: str,
     config_file: str | None = None,
     layout: Layout | None = None,
 ) -> None:

--- a/src/zkeymap/generators.py
+++ b/src/zkeymap/generators.py
@@ -432,7 +432,7 @@ def build_layout_svg_drawer(
     try:
         from keymap_drawer.draw import KeymapDrawer
         from keymap_drawer.physical_layout import QmkLayout
-        from keymap_drawer.config import Config
+        from keymap_drawer.config import Config, DrawConfig
     except ImportError:
         print("[ERROR] keymap_drawer is not installed.")
         sys.exit(-1)
@@ -452,7 +452,7 @@ def build_layout_svg_drawer(
                 yaml.safe_load(config_h)
             )
     else:
-        config_obj = Config()
+        config_obj = Config(draw_config=DrawConfig(dark_mode="auto"))
 
     if not layout:
         layout = main_layout


### PR DESCRIPTION
Here is a way to use keymap-drawer at a lower level, skipping parsing of the keymap and directly constructing a KeymapDrawer structure from layers+layout. This way you can customize the labels and use the hold/shifted fields for your own token types (I left a couple comments on the code).